### PR TITLE
feat: add prizeIndex attribute

### DIFF
--- a/src/game/entities/draw-result.entity.ts
+++ b/src/game/entities/draw-result.entity.ts
@@ -19,6 +19,12 @@ export class DrawResult {
   })
   prizeCategory: string;
 
+  @Column({
+    comment: 'index based on number array return by smart contract.',
+    // 0 is first prize, 1 is second prize, 2 is third prize, 3-13 is special prize, 14-32 is consolation prize
+  })
+  prizeIndex: number;
+
   @Column()
   numberPair: string;
 


### PR DESCRIPTION
Add new attribute `prizeIndex` in `draw-result.entity`.

This is because `claim` function in `Core.sol` accept `prizeIndex` instead of `prizeCategory`.

And `Core.sol` want to know exactly which index located for special & consolation prize, for checking purpose.

`Core.drawResults` function return an array of results, start from 0 to 32, where 0 represent first prize, 1 represent second prize, 2 represent third prize, 3-12 represent special prize and 13-32 represent consolation prize.

Looping check for special prize and consolation prize in `Core.sol` based on numberPair(string) is expensive in term of gas fee.

Also, if do it off-chain, keep calling `Core.drawResults` function also got rate limit issue, because we need to call it for each claim especially with different epoch.