### PR TITLE
Bet Module: Fix negative redeemable balance

### DIFF
--- a/src/game/bet.service.ts
+++ b/src/game/bet.service.ts
@@ -864,9 +864,17 @@ export class BetService {
         },
       });
 
+      const oldWalletBalance = userWallet.walletBalance;
+      const nonRedeemableWalletBalance =
+        oldWalletBalance - userWallet.redeemableBalance;
+
+      if (payload.walletTx.txAmount > nonRedeemableWalletBalance) {
+        userWallet.redeemableBalance -=
+          payload.walletTx.txAmount - nonRedeemableWalletBalance;
+      }
+
       userWallet.walletBalance = payload.walletTx.endingBalance;
       userWallet.creditBalance = previousEndingCreditBalance;
-      userWallet.redeemableBalance -= payload.walletTx.txAmount;
 
       await queryRunner.manager.save(userWallet);
 


### PR DESCRIPTION
After a successful bet, The `user_wallet.walletBalance` is reduced first. 
If the betAmount is larger than the non-redeemable amount `(i.e, walletBalance - RedeemableBalance)`, The excess value is reduced from `redeemableBalance`