### PR TITLE
Hotfix - Telegram Login widget

### DIFF
--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -73,7 +73,7 @@ export class LoginWithTelegramDTO {
 
   @ApiProperty()
   @IsString()
-  @IsNotEmpty()
+  @IsOptional()
   photo_url: string;
 
   @ApiProperty()


### PR DESCRIPTION
Makes the photo_url field in DTO optional.