### PR TITLE
Fix Duplicate BetOrder

### DIFF
--- a/src/wallet/services/claim.service.ts
+++ b/src/wallet/services/claim.service.ts
@@ -560,7 +560,7 @@ export class ClaimService implements OnModuleInit {
 
     const allWalletTxs = [...walletTxs, ...creditWalletTxs];
 
-    let betOrders: BetOrder[] = [];
+    const betOrders: BetOrder[] = [];
     for (const walletTx of allWalletTxs) {
       const _betOrders = await this.betOrderRepository
         .createQueryBuilder('betOrder')
@@ -579,7 +579,14 @@ export class ClaimService implements OnModuleInit {
         })
         .getMany();
 
-      betOrders = [...betOrders, ..._betOrders];
+      // if a betOrder contains both walletTxs and creditWalletTxs,
+      // there will be two same betOrder(with the same id) in allWalletTxs
+      // below filter out the duplicate betOrders
+      for (const _betOrder of _betOrders) {
+        if (!betOrders.some((betOrder) => betOrder.id === _betOrder.id)) {
+          betOrders.push(_betOrder);
+        }
+      }
     }
 
     return {


### PR DESCRIPTION
We get the availableClaim = true betOrders through both walletTxs & creditWalletTxs, and if a betOrder contains both walletTx & creditWalletTx(bet with USDT + credit), when looping there will be duplicate betOrder.