### PR TITLE
Improve My tickets API Performance

### DIFF
--- a/src/wallet/wallet.service.ts
+++ b/src/wallet/wallet.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Brackets, DataSource, QueryRunner, Repository } from 'typeorm';
 import { UserWallet } from './entities/user-wallet.entity';
@@ -25,7 +25,9 @@ type TransactionHistory = {
 
 @Injectable()
 export class WalletService {
+  private readonly logger = new Logger(WalletService.name);
   levelMap = [];
+
   constructor(
     @InjectRepository(UserWallet)
     private userWalletRepository: Repository<UserWallet>,
@@ -211,7 +213,7 @@ export class WalletService {
         .createQueryBuilder(BetOrder, 'betOrder')
         .innerJoinAndSelect('betOrder.gameUsdTx', 'gameUsdTx')
         .leftJoinAndSelect('betOrder.game', 'game')
-        .leftJoinAndSelect('game.drawResult', 'drawResult')
+        // .leftJoinAndSelect('game.drawResult', 'drawResult')
         .leftJoinAndSelect('betOrder.walletTx', 'walletTx')
         .leftJoinAndSelect('betOrder.creditWalletTx', 'creditWalletTx')
         .leftJoinAndSelect('walletTx.userWallet', 'walletTxUserWallet')
@@ -235,7 +237,7 @@ export class WalletService {
 
       return groupedBetOrders;
     } catch (error) {
-      console.error(error);
+      this.logger.error(error);
 
       return [];
     }
@@ -309,7 +311,7 @@ export class WalletService {
       await queryRunner.manager.save(usdtTx);
       return walletTx;
     } catch (error) {
-      console.error(error);
+      this.logger.error(error);
       if (!runner) await queryRunner.rollbackTransaction();
     } finally {
       if (!runner && !queryRunner.isReleased) await queryRunner.release();


### PR DESCRIPTION
1. Comment out unused `.leftJoinAndSelect('game.drawResult', 'drawResult')`, this make database query a lot slower and seems unused.
2. Utilize Nestjs native Logger for error logging.