### PR TITLE
Fix Possibly txResponse.wait() Not Responding

### DIFF
--- a/src/shared/utils/on-chain.util.ts
+++ b/src/shared/utils/on-chain.util.ts
@@ -1,0 +1,19 @@
+import { ethers } from 'ethers';
+
+export class OnChainUtil {
+  static async waitForTransaction(
+    txResponse: ethers.TransactionResponse,
+    provider: ethers.Provider,
+  ): Promise<ethers.TransactionReceipt | null> {
+    let txReceipt: ethers.TransactionReceipt | null;
+    // wait for 1 confirmation block or 1 minute
+    txReceipt = await txResponse.wait(1, 60000);
+    if (!txReceipt) {
+      // 1 minute timeout and txResponse.wait() return null
+      // try to get receipt from rpc provider
+      // this is still null possible
+      txReceipt = await provider.getTransactionReceipt(txResponse.hash);
+    }
+    return txReceipt;
+  }
+}


### PR DESCRIPTION
This PR create a new OnChainUtil to handle txResponse.wait()
It first execute `txResponse.wait()` with params confirmation block = 1 and timeout = 1 minute.
`txResponse.wait()` will return null after no responding for 1 minute.
Then, it try to get transaction receipt via query through RPC provider(`provider.getTransactionReceipt`, additional RPC call).
It is still possible that `provider.getTransactionReceipt` return null for some reason.
In this case, we update depositTx.status to pending developer, send admin notification, and exit silently to prevent on-chain tx(token transfer) to execute again.

p/s: Please use Alchemy for RPC(free version should be good enough for us for now).