### PR TITLE
Fix Null User Content on chat_log Records

### DIFF
--- a/src/shared/services/telegram.service.ts
+++ b/src/shared/services/telegram.service.ts
@@ -51,7 +51,8 @@ export class TelegramService {
       }
     });
     this.fuyoBot.on('message', async (msg) => {
-      if (msg.text && msg.text.startsWith('/')) return;
+      if (!msg.text) return;
+      if (msg.text.startsWith('/')) return;
 
       await this.handleChatWithAIMessage(msg);
     });


### PR DESCRIPTION
Telegram AI message send directly to chatbot.service.sendMessage(), and although the function use type SendMessageDto with null and empty check, the validation won't work in service(only work in controller).

And Telegram AI message msg.text is missing null check.

On live server, all null content patched with 'hi'. chat_log.id that did patched for record purpose:
1922, 1947, 1950, 1975, 2084, 2115, 2174, 2241, 2287, 2290, 2433, 2512, 2523, 2630, 2773, 3033, 3162, 3173, 3218, 3571, 3574, 3595, 3618, 3628, 3635, 3720, 3759, 3774, 3811, 3816, 3818, 3967, 3970, 3991, 3992, 3993, 3995, 3998, 3999, 4011, 4012, 4022, 4040, 4055, 4072, 4073, 4074, 4075, 4076, 4111, 4158, 4159, 4177, 4180, 4196, 4208, 4217, 4222, 4261, 4314