### PR TITLE
Fix Credit Expiration Issues

### DIFF
--- a/src/shared/enum/txType.enum.ts
+++ b/src/shared/enum/txType.enum.ts
@@ -17,6 +17,7 @@ export enum ReferralTxType {
   SET_REFERRAL = 'SET_REFERRAL',
 }
 
+// please update credit.service.expireCredits() if new enum is added
 export enum CreditWalletTxType {
   CREDIT = 'CREDIT',
   PLAY = 'PLAY',

--- a/src/wallet/services/credit.service.ts
+++ b/src/wallet/services/credit.service.ts
@@ -669,7 +669,7 @@ export class CreditService {
           ],
         })
         // use creditBalance > 0 to reduce database query
-        // creditBalance goes 0 if all credits are expired
+        // creditBalance goes 0 if all credits are used up or expired
         .andWhere('creditBalance > 0')
         .groupBy('userWallet.id')
         .getRawMany();


### PR DESCRIPTION
1. Remove usage of credit wallet tx status 'E'.
2. Use simpler method to calculate expired credit that haven't update yet: total amount of all "in" credit wallet txs that expirationDate < new Date() - total amount of all "out" credit wallet txs. It is okay that the operation result goes negative(total amount "out" credit wallet txs > total amount "in" credit wallet txs that expirationDate < new Date(), user used up credit that haven't expired yet).
3. Remove unused codebase.