### PR TITLE
Fix Missing Response When Reload Native Token for Gas Purpose

### DIFF
--- a/src/shared/utils/on-chain.util.ts
+++ b/src/shared/utils/on-chain.util.ts
@@ -14,7 +14,9 @@ export class OnChainUtil {
       }
     } catch (error) {
       // if timeout, wait() will throw error "wait for transaction timeout"
-      console.log('error', error);
+      console.log(
+        `${new Date()} waitForTransaction() error: ${error}, txResponse: ${txResponse.hash}`,
+      );
       // try to get receipt from second provider
       txReceipt = await backupProvider.getTransactionReceipt(txResponse.hash);
       if (!txReceipt) {

--- a/src/wallet/services/deposit.service.ts
+++ b/src/wallet/services/deposit.service.ts
@@ -65,6 +65,11 @@ import { I18nService } from 'nestjs-i18n';
 @Injectable()
 export class DepositService implements OnModuleInit {
   private readonly logger = new Logger(DepositService.name);
+  backupProvider = new ethers.JsonRpcProvider(
+    this.configService.get(
+      'PROVIDER_RPC_URL_BACKUP_' + this.configService.get('BASE_CHAIN_ID'),
+    ),
+  );
 
   constructor(
     @InjectRepository(UserWallet)
@@ -574,7 +579,7 @@ export class DepositService implements OnModuleInit {
       // into catch block and retry again in next cron job
       const receipt = await OnChainUtil.waitForTransaction(
         onchainEscrowTx,
-        userSigner.provider,
+        this.backupProvider,
       );
       if (!receipt) {
         this.logger.error(
@@ -1325,7 +1330,10 @@ export class DepositService implements OnModuleInit {
           to: walletAddress,
           value: ethers.parseEther(amount),
         });
-        const txReceipt = await txResponse.wait();
+        const txReceipt = await OnChainUtil.waitForTransaction(
+          txResponse,
+          this.backupProvider,
+        );
         if (!txReceipt || txReceipt.status !== 1) {
           throw new Error(
             `Failed to reload native token on-chain in chain ${chainId}`,


### PR DESCRIPTION
Replace `.wait()` with `OnChainUtil.waitForTransaction()` to utilize the backup provider.