### PR TITLE
Fallback Provider

### DIFF
--- a/src/campaign/campaign.cron.ts
+++ b/src/campaign/campaign.cron.ts
@@ -14,6 +14,7 @@ import { BetOrder } from 'src/game/entities/bet-order.entity';
 import { User } from 'src/user/entities/user.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { I18nService } from 'nestjs-i18n';
+import { ProviderUtil } from 'src/shared/utils/provider.util';
 
 @Injectable()
 export class CampaignCron {
@@ -73,10 +74,8 @@ export class CampaignCron {
           });
           if (betOrders.length === 0) return;
 
-          const provider = new ethers.JsonRpcProvider(
-            this.configService.get(
-              `PROVIDER_RPC_URL_${this.configService.get('BASE_CHAIN_ID')}`,
-            ),
+          const provider = ProviderUtil.createFallbackProvider(
+            this.configService.get('BASE_CHAIN_ID'),
           );
           const cashbackDistributerAddress = this.configService.get(
             'CASHBACK_DISTRIBUTER_ADDRESS',

--- a/src/game/bet.service.ts
+++ b/src/game/bet.service.ts
@@ -21,6 +21,7 @@ import {
   Wallet,
   ethers,
   parseUnits,
+  Provider,
 } from 'ethers';
 import {
   Core__factory,
@@ -55,6 +56,7 @@ import { Jackpot } from './entities/jackpot.entity';
 import { SquidGameParticipant } from 'src/campaign/entities/squidGame.participant.entity';
 import { AdminNotificationService } from 'src/shared/services/admin-notification.service';
 import { I18nService } from 'nestjs-i18n';
+import { ProviderUtil } from 'src/shared/utils/provider.util';
 
 interface SubmitBetJobDTO {
   userWalletId: number;
@@ -82,6 +84,9 @@ interface ParticipateJackpotDTO {
 export class BetService implements OnModuleInit {
   private readonly logger = new Logger(BetService.name);
   private readonly MAX_NUMBER_OF_DRAWS = 168;
+  private provider = ProviderUtil.createFallbackProvider(
+    this.configService.get('BASE_CHAIN_ID'),
+  );
 
   constructor(
     // @InjectRepository(Game)
@@ -818,7 +823,7 @@ export class BetService implements OnModuleInit {
     ticketId: number,
     payload: BetOrder[],
     userSigner: Wallet,
-    provider: JsonRpcProvider,
+    provider: Provider,
   ) {
     try {
       const coreContractAddr = this.configService.get('CORE_CONTRACT_ADDRESS');
@@ -986,14 +991,9 @@ export class BetService implements OnModuleInit {
         return true;
       }
 
-      const provider = new JsonRpcProvider(
-        this.configService.get(
-          `PROVIDER_RPC_URL_${this.configService.get('BASE_CHAIN_ID')}`,
-        ),
-      );
       const userSigner = new Wallet(
         await MPC.retrievePrivateKey(userWallet.walletAddress),
-        provider,
+        this.provider,
       );
 
       // console.log('submitting bet', betOrders);
@@ -1002,10 +1002,12 @@ export class BetService implements OnModuleInit {
         gameUsdTxId,
         betOrders,
         userSigner,
-        provider,
+        this.provider,
       );
 
-      const txReceipt = await provider.getTransactionReceipt(onchainTx.hash);
+      const txReceipt = await this.provider.getTransactionReceipt(
+        onchainTx.hash,
+      );
       if (txReceipt && txReceipt.status === 1) {
         // Need to commit transaction immediately if onchain tx is successful
         // This is the reason why need queue to prevent re-submit onchain again if failed to execute job and retry
@@ -1322,16 +1324,11 @@ export class BetService implements OnModuleInit {
         +this.configService.get('BASE_CHAIN_ID'),
       );
 
-      const provider = new JsonRpcProvider(
-        this.configService.get(
-          'PROVIDER_RPC_URL_' + this.configService.get('BASE_CHAIN_ID'),
-        ),
-      );
       const distributeReferralFeeBot = new Wallet(
         await MPC.retrievePrivateKey(
           this.configService.get('DISTRIBUTE_REFERRAL_FEE_BOT_ADDRESS'),
         ),
-        provider,
+        this.provider,
       );
       const depositContract = Deposit__factory.connect(
         this.configService.get('DEPOSIT_CONTRACT_ADDRESS'),
@@ -1648,11 +1645,7 @@ export class BetService implements OnModuleInit {
       // participate jackpot on-chain tx is executed by user wallet
       const userSigner = new Wallet(
         await MPC.retrievePrivateKey(walletAddress),
-        new JsonRpcProvider(
-          this.configService.get(
-            'PROVIDER_RPC_URL_' + this.configService.get('BASE_CHAIN_ID'),
-          ),
-        ),
+        this.provider,
       );
       const jackpotContract = Jackpot__factory.connect(
         this.configService.get('JACKPOT_CONTRACT_ADDRESS'),
@@ -1753,11 +1746,7 @@ export class BetService implements OnModuleInit {
           await MPC.retrievePrivateKey(
             this.configService.get('DISTRIBUTE_REFERRAL_FEE_BOT_ADDRESS'),
           ),
-          new JsonRpcProvider(
-            this.configService.get(
-              'PROVIDER_RPC_URL_' + this.configService.get('BASE_CHAIN_ID'),
-            ),
-          ),
+          this.provider,
         ),
       );
 
@@ -1878,11 +1867,9 @@ export class BetService implements OnModuleInit {
     userWallet: UserWallet,
     chainId: number,
   ): Promise<boolean> {
-    const provider = new JsonRpcProvider(
-      this.configService.get('OPBNB_PROVIDER_RPC_URL'),
+    const nativeBalance = await this.provider.getBalance(
+      userWallet.walletAddress,
     );
-
-    const nativeBalance = await provider.getBalance(userWallet.walletAddress);
 
     const minimumNativeBalance = this.configService.get(
       `MINIMUM_NATIVE_BALANCE_${chainId}`,

--- a/src/game/game.service.ts
+++ b/src/game/game.service.ts
@@ -56,19 +56,23 @@ import { BetService } from './bet.service';
 import { OnChainUtil } from 'src/shared/utils/on-chain.util';
 import { delay } from 'src/shared/constants/util.constant';
 import { I18nService } from 'nestjs-i18n';
+import { ProviderUtil } from 'src/shared/utils/provider.util';
 
 @Injectable()
 export class GameService implements OnModuleInit {
   private readonly logger = new Logger(GameService.name);
-  provider = new ethers.JsonRpcProvider(
-    this.configService.get(
-      'PROVIDER_RPC_URL_' + this.configService.get('BASE_CHAIN_ID'),
-    ),
-  );
-  backupProvider = new ethers.JsonRpcProvider(
-    this.configService.get(
-      'PROVIDER_RPC_URL_BACKUP_' + this.configService.get('BASE_CHAIN_ID'),
-    ),
+  // provider = new ethers.JsonRpcProvider(
+  //   this.configService.get(
+  //     'PROVIDER_RPC_URL_' + this.configService.get('BASE_CHAIN_ID'),
+  //   ),
+  // );
+  // backupProvider = new ethers.JsonRpcProvider(
+  //   this.configService.get(
+  //     'PROVIDER_RPC_URL_BACKUP_' + this.configService.get('BASE_CHAIN_ID'),
+  //   ),
+  // );
+  private provider = ProviderUtil.createFallbackProvider(
+    this.configService.get('BASE_CHAIN_ID'),
   );
 
   constructor(
@@ -399,10 +403,11 @@ export class GameService implements OnModuleInit {
         },
       );
       console.log('Response waiting');
-      const txReceipt = await OnChainUtil.waitForTransaction(
-        txResponse,
-        this.backupProvider,
-      );
+      // const txReceipt = await OnChainUtil.waitForTransaction(
+      //   txResponse,
+      //   this.backupProvider,
+      // );
+      const txReceipt = await txResponse.wait();
       console.log('Finished wait');
 
       const game = await queryRunner.manager

--- a/src/public/public.service.ts
+++ b/src/public/public.service.ts
@@ -60,6 +60,7 @@ import { RedeemTx } from 'src/wallet/entities/redeem-tx.entity';
 import { ChatLog } from 'src/chatbot/entities/chatLog.entity';
 import { ChatbotService } from 'src/chatbot/chatbot.service';
 import { I18nContext } from 'nestjs-i18n';
+import { ProviderUtil } from 'src/shared/utils/provider.util';
 
 @Injectable()
 export class PublicService {
@@ -850,8 +851,8 @@ export class PublicService {
 
       let receipt: ContractTransactionReceipt;
       try {
-        const provider = new JsonRpcProvider(
-          this.configService.get(`PROVIDER_RPC_URL_${usdtTx.chainId}`),
+        const provider = ProviderUtil.createFallbackProvider(
+          usdtTx.chainId.toString(),
         );
         const signer = new Wallet(
           await MPC.retrievePrivateKey(usdtTx.senderAddress),

--- a/src/shared/services/gas.service.ts
+++ b/src/shared/services/gas.service.ts
@@ -14,6 +14,7 @@ import { Mutex } from 'async-mutex';
 import { ConfigService } from 'src/config/config.service';
 import { TxStatus } from '../enum/status.enum';
 import { MultiCall__factory } from 'src/contract';
+import { ProviderUtil } from '../utils/provider.util';
 
 @Injectable()
 export class GasService {
@@ -39,10 +40,7 @@ export class GasService {
     userAddress: string,
     chainId: number,
   ): Promise<void> {
-    const provider_rpc_url = this.configService.get(
-      `PROVIDER_RPC_URL_${chainId.toString()}`,
-    );
-    const provider = new ethers.JsonRpcProvider(provider_rpc_url);
+    const provider = ProviderUtil.createFallbackProvider(chainId.toString());
     const balance = await provider.getBalance(userAddress);
 
     if (balance < ethers.parseEther('0.001')) {
@@ -75,11 +73,6 @@ export class GasService {
         // no reloadTx for admin reload because
         // no userWallet for admin (userWalletId is compulsory)
         // just simply reload admin wallet
-        const provider_rpc_url = this.configService.get(
-          `PROVIDER_RPC_URL_${chainId.toString()}`,
-        );
-        const provider = new ethers.JsonRpcProvider(provider_rpc_url);
-
         // no error handling for admin wallet reload
         // try again in next reload
         const supplyAccount = new ethers.Wallet(
@@ -130,10 +123,7 @@ export class GasService {
       if (reloadTxs.length === 0) return;
       this.logger.log(`reloadTxs.length: ${reloadTxs.length}`);
 
-      const provider_rpc_url = this.configService.get(
-        `PROVIDER_RPC_URL_${chainId.toString()}`,
-      );
-      const provider = new ethers.JsonRpcProvider(provider_rpc_url);
+      const provider = ProviderUtil.createFallbackProvider(chainId.toString());
       const supplyAccount = new ethers.Wallet(
         await MPC.retrievePrivateKey(
           this.configService.get('SUPPLY_ACCOUNT_ADDRESS'),
@@ -263,10 +253,7 @@ export class GasService {
     walletAddress: string,
     chainId: number,
   ): Promise<ethers.TransactionReceipt> {
-    const provider_rpc_url = this.configService.get(
-      `PROVIDER_RPC_URL_${chainId.toString()}`,
-    );
-    const provider = new ethers.JsonRpcProvider(provider_rpc_url);
+    const provider = ProviderUtil.createFallbackProvider(chainId.toString());
     const supplyAccount = new ethers.Wallet(
       await MPC.retrievePrivateKey(
         this.configService.get('SUPPLY_ACCOUNT_ADDRESS'),

--- a/src/shared/utils/provider.util.ts
+++ b/src/shared/utils/provider.util.ts
@@ -1,0 +1,29 @@
+import { FallbackProvider, JsonRpcProvider } from 'ethers';
+import 'dotenv/config';
+
+export class ProviderUtil {
+  public static createFallbackProvider = (chainId: string) => {
+    return new FallbackProvider(
+      [
+        {
+          provider: new JsonRpcProvider(
+            process.env[`PROVIDER_RPC_URL_${chainId}`],
+          ),
+          priority: 1,
+          stallTimeout: 3000,
+          weight: 2,
+        },
+        {
+          provider: new JsonRpcProvider(
+            process.env[`PROVIDER_RPC_URL_BACKUP_${chainId}`],
+          ),
+          priority: 2,
+          stallTimeout: 6000,
+          weight: 1,
+        },
+      ],
+      undefined,
+      { quorum: 1 },
+    );
+  };
+}

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -66,6 +66,7 @@ import { QueueName, QueueType } from 'src/shared/enum/queue.enum';
 import { Job } from 'bullmq';
 import { NotificationType } from 'src/shared/dto/admin-notification.dto';
 import { Language } from './dto/update-user-language.dto';
+import { ProviderUtil } from 'src/shared/utils/provider.util';
 
 const depositBotAddAddress = process.env.DEPOSIT_BOT_SERVER_URL;
 type SetReferrerEvent = {
@@ -1110,9 +1111,9 @@ export class UserService implements OnModuleInit {
 
   private async _getSigner(walletAddress: string): Promise<ethers.Wallet> {
     try {
-      const chainId = this.configService.get('BASE_CHAIN_ID');
-      const providerUrl = this.configService.get(`PROVIDER_RPC_URL_${chainId}`);
-      const provider = new ethers.JsonRpcProvider(providerUrl);
+      const provider = ProviderUtil.createFallbackProvider(
+        this.configService.get('BASE_CHAIN_ID'),
+      );
       const signer = new ethers.Wallet(
         await MPC.retrievePrivateKey(walletAddress),
         provider,

--- a/src/wallet/services/credit.service.ts
+++ b/src/wallet/services/credit.service.ts
@@ -40,6 +40,7 @@ import { TxStatus } from 'src/shared/enum/status.enum';
 import axios from 'axios';
 import { I18nService } from 'nestjs-i18n';
 import { FCMService } from 'src/shared/services/fcm.service';
+import { ProviderUtil } from 'src/shared/utils/provider.util';
 
 @Injectable()
 export class CreditService {
@@ -442,8 +443,7 @@ export class CreditService {
   }
 
   private async getSigner(chainId: number, address: string): Promise<Wallet> {
-    const providerUrl = this.configService.get(`PROVIDER_RPC_URL_${chainId}`);
-    const provider = new JsonRpcProvider(providerUrl);
+    const provider = ProviderUtil.createFallbackProvider(chainId.toString());
     const signerPrivKey = await MPC.retrievePrivateKey(address);
 
     return new Wallet(signerPrivKey, provider);

--- a/src/wallet/services/deposit.service.ts
+++ b/src/wallet/services/deposit.service.ts
@@ -580,10 +580,11 @@ export class DepositService implements OnModuleInit {
       // if transfer token failed, normally due to insufficient gas fee, means
       // user wallet haven't been reloaded yet in processDeposit() especially new created wallet
       // into catch block and retry again in next cron job
-      const receipt = await OnChainUtil.waitForTransaction(
-        onchainEscrowTx,
-        this.backupProvider,
-      );
+      // const receipt = await OnChainUtil.waitForTransaction(
+      //   onchainEscrowTx,
+      //   this.backupProvider,
+      // );
+      const receipt = await onchainEscrowTx.wait();
       if (!receipt) {
         this.logger.error(
           `handleEscrowTx() error: Transaction receipt not found for depositTxId: ${depositTx.id}`,
@@ -1329,10 +1330,11 @@ export class DepositService implements OnModuleInit {
           to: walletAddress,
           value: ethers.parseEther(amount),
         });
-        const txReceipt = await OnChainUtil.waitForTransaction(
-          txResponse,
-          this.backupProvider,
-        );
+        // const txReceipt = await OnChainUtil.waitForTransaction(
+        //   txResponse,
+        //   this.backupProvider,
+        // );
+        const txReceipt = await txResponse.wait();
         if (!txReceipt || txReceipt.status !== 1) {
           throw new Error(
             `Failed to reload native token on-chain in chain ${chainId}`,

--- a/src/wallet/services/deposit.service.ts
+++ b/src/wallet/services/deposit.service.ts
@@ -49,6 +49,7 @@ import { GasService } from 'src/shared/services/gas.service';
 import { ReloadTx } from '../entities/reload-tx.entity';
 import { OnChainUtil } from 'src/shared/utils/on-chain.util';
 import { I18nService } from 'nestjs-i18n';
+import { ProviderUtil } from 'src/shared/utils/provider.util';
 /**
  * How deposit works
  * 1. deposit-bot access via api/v1/wallet/deposit
@@ -694,8 +695,7 @@ export class DepositService implements OnModuleInit {
     walletAddress: string,
     chainId: number,
   ): Promise<ethers.Wallet> {
-    const providerUrl = this.configService.get(`PROVIDER_RPC_URL_${chainId}`);
-    const provider = new ethers.JsonRpcProvider(providerUrl);
+    const provider = ProviderUtil.createFallbackProvider(chainId.toString());
     return new ethers.Wallet(
       await MPC.retrievePrivateKey(walletAddress),
       provider,
@@ -1321,10 +1321,7 @@ export class DepositService implements OnModuleInit {
 
     const baseChainId = Number(this.configService.get('BASE_CHAIN_ID'));
     if (chainId !== baseChainId) {
-      const chain_provider_rpc_url = this.configService.get(
-        `PROVIDER_RPC_URL_${chainId.toString()}`,
-      );
-      const provider = new ethers.JsonRpcProvider(chain_provider_rpc_url);
+      const provider = ProviderUtil.createFallbackProvider(chainId.toString());
       const balance = await provider.getBalance(walletAddress);
       if (balance <= ethers.parseEther(amount)) {
         const chainSupplyAccount = supplyAccount.connect(provider);
@@ -1359,10 +1356,9 @@ export class DepositService implements OnModuleInit {
       }
     }
 
-    const base_chain_provider_rpc_url = this.configService.get(
-      `PROVIDER_RPC_URL_${baseChainId.toString()}`,
+    const provider = ProviderUtil.createFallbackProvider(
+      baseChainId.toString(),
     );
-    const provider = new ethers.JsonRpcProvider(base_chain_provider_rpc_url);
     const balance = await provider.getBalance(walletAddress);
     if (balance <= ethers.parseEther(amount)) {
       const chainSupplyAccount = supplyAccount.connect(provider);

--- a/src/wallet/services/internal-transfer.service.ts
+++ b/src/wallet/services/internal-transfer.service.ts
@@ -23,6 +23,7 @@ import { WalletTxType } from 'src/shared/enum/txType.enum';
 import { TxStatus } from 'src/shared/enum/status.enum';
 import { FCMService } from 'src/shared/services/fcm.service';
 import { I18nService } from 'nestjs-i18n';
+import { ProviderUtil } from 'src/shared/utils/provider.util';
 
 @Injectable()
 export class InternalTransferService {
@@ -328,10 +329,8 @@ export class InternalTransferService {
       senderUserWallet = senderWalletTx.userWallet;
       receiverUserWallet = receiverWalletTx.userWallet;
 
-      const provider = new JsonRpcProvider(
-        this.configService.get(
-          'PROVIDER_RPC_URL_' + this.configService.get('BASE_CHAIN_ID'),
-        ),
+      const provider = ProviderUtil.createFallbackProvider(
+        this.configService.get('BASE_CHAIN_ID'),
       );
 
       const userSigner = new Wallet(
@@ -507,9 +506,7 @@ export class InternalTransferService {
     chainId: number,
   ): Promise<boolean> {
     try {
-      const provider = new JsonRpcProvider(
-        this.configService.get('PROVIDER_RPC_URL_' + chainId.toString()),
-      );
+      const provider = ProviderUtil.createFallbackProvider(chainId.toString());
 
       const nativeBalance = await provider.getBalance(userWallet.walletAddress);
 

--- a/src/wallet/services/withdraw.service.ts
+++ b/src/wallet/services/withdraw.service.ts
@@ -39,6 +39,7 @@ import { TxStatus, UserStatus } from 'src/shared/enum/status.enum';
 import { WalletTxType } from 'src/shared/enum/txType.enum';
 import { FCMService } from 'src/shared/services/fcm.service';
 import { I18nContext, I18nService } from 'nestjs-i18n';
+import { ProviderUtil } from 'src/shared/utils/provider.util';
 
 type RedeemResponse = {
   error: string;
@@ -711,12 +712,8 @@ export class WithdrawService implements OnModuleInit {
   }
 
   private async approveGameUsdToken(from: string, minApproval: number) {
-    // const providerUrl = process.env.OPBNB_PROVIDER_RPC_URL;
-    // const provider = new ethers.JsonRpcProvider(providerUrl);
-    const provider = new ethers.JsonRpcProvider(
-      this.configService.get(
-        'PROVIDER_RPC_URL_' + this.configService.get('BASE_CHAIN_ID'),
-      ),
+    const provider = ProviderUtil.createFallbackProvider(
+      this.configService.get('BASE_CHAIN_ID'),
     );
     const signer = new ethers.Wallet(
       await MPC.retrievePrivateKey(from),
@@ -756,12 +753,8 @@ export class WithdrawService implements OnModuleInit {
     );
   }
   private async withdrawGameUSD(from: string, amount: number, fee: number) {
-    // const providerUrl = process.env.OPBNB_PROVIDER_RPC_URL;
-    // const provider = new ethers.JsonRpcProvider(providerUrl);
-    const provider = new ethers.JsonRpcProvider(
-      this.configService.get(
-        'PROVIDER_RPC_URL_' + this.configService.get('BASE_CHAIN_ID'),
-      ),
+    const provider = ProviderUtil.createFallbackProvider(
+      this.configService.get('BASE_CHAIN_ID'),
     );
     const withdrawBot = new ethers.Wallet(
       await MPC.retrievePrivateKey(
@@ -808,10 +801,6 @@ export class WithdrawService implements OnModuleInit {
   }
 
   private async getUsdtBalance(chainId: number): Promise<bigint> {
-    const providerUrl =
-      chainId === 56 || chainId === 97
-        ? this.configService.get('BNB_PROVIDER_RPC_URL')
-        : this.configService.get('OPBNB_PROVIDER_RPC_URL');
     const tokenAddress =
       chainId === 56 || chainId === 97
         ? this.configService.get('BNB_USDT_TOKEN_ADDRESS')
@@ -821,7 +810,7 @@ export class WithdrawService implements OnModuleInit {
         ? this.configService.get('BNB_PAYOUT_POOL_CONTRACT_ADDRESS')
         : this.configService.get('OPBNB_PAYOUT_POOL_CONTRACT_ADDRESS');
 
-    const provider = new ethers.JsonRpcProvider(providerUrl);
+    const provider = ProviderUtil.createFallbackProvider(chainId.toString());
     const usdtTokenContract = GameUSD__factory.connect(tokenAddress, provider);
     return await usdtTokenContract.balanceOf(payoutPoolAddress);
   }
@@ -833,10 +822,7 @@ export class WithdrawService implements OnModuleInit {
     signature: BytesLike,
   ): Promise<ethers.TransactionReceipt> {
     try {
-      const providerUrl = this.configService.get(
-        'PROVIDER_RPC_URL_' + chainId.toString(),
-      );
-      const provider = new ethers.JsonRpcProvider(providerUrl);
+      const provider = ProviderUtil.createFallbackProvider(chainId.toString());
       const payoutBot = new ethers.Wallet(
         await MPC.retrievePrivateKey(
           this.configService.get('PAYOUT_BOT_ADDRESS'),


### PR DESCRIPTION
Utilize ethers.js fallback provider.

Quote from ethers.js docs:

> A FallbackProvider manages several Providers providing resilience by switching between slow or misbehaving nodes, security by requiring multiple backends to agree and performance by allowing faster backends to respond earlier.

Main script is: src/shared/utils/provider.util.ts. It utilize provider rpc url and backup provider rpc url from .env, try use provider rpc url first, if timeout(3 seconds) waiting for response or error, it will use backup provider rpc url.

Ref: https://docs.ethers.org/v6/api/providers/fallback-provider/